### PR TITLE
Fix physical equality match

### DIFF
--- a/after/syntax/ocaml.vim
+++ b/after/syntax/ocaml.vim
@@ -16,7 +16,7 @@ syntax keyword ocamlNiceOperator rec conceal cchar=Γ
 syntax match ocamlNiceOperator "<-" conceal cchar=←
 syntax match ocamlNiceOperator "->" conceal cchar=→
 syntax match ocamlNiceOperator "\<sqrt\>" conceal cchar=√ 
-syntax match ocamlNiceOperator "\<==\>" conceal cchar=≡
+syntax match ocamlNiceOperator "==" conceal cchar=≡
 syntax match ocamlNiceOperator "<>" conceal cchar=≠
 syntax match ocamlNiceOperator "||" conceal cchar=∨
 syntax match ocamlNiceOperator "@" conceal cchar=⊕


### PR DESCRIPTION
`\<==\>` doesn't seem to match correctly; `==` works
